### PR TITLE
Bug/issue 15 relax teardown and add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,21 @@ await runner.runCommand(
 ```
 
 ### Runner.teardown
-`Runner.teardown` deletes the directory provided in `Runner.setup`.  Returns a `Promise`.
+`Runner.teardown` deletes any `setupFiles` provided in `Runner.setup`.  Returns a `Promise`.
 
 ```js
 await runner.teardown();
+```
+
+You can pass additional files or directories to `teardown` to have **gallinago** delete those too.
+```js
+await runner.teardown([
+  path.join(__dirname, 'build'),
+  path.join(__dirname, 'fixtures'),
+  .
+  .
+  .
+]);
 ```
 
 > _See [our tests](https://github.com/thescientist13/gallinago/blob/master/test/cases/runner-cli/runner.cli.spec.js) to see **Gallinago** in action._

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -16,8 +16,8 @@ module.exports = {
   checkCoverage: true,
 
   statements: 90,
-  branches: 75,
-  functions: 90,
+  branches: 85,
+  functions: 95,
   lines: 90,
 
   watermarks: {

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -16,7 +16,7 @@ module.exports = {
   checkCoverage: true,
 
   statements: 90,
-  branches: 85,
+  branches: 80,
   functions: 95,
   lines: 90,
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #15 

## Summary of Changes
1. Changed `teardown` to not delete setup directory
1. `teardown` will clean up `setupFiles` and any other additional files / directories provided
1. Updated README and test cases
1. Was able to improve test coverage thresholds 💯 