### PR TITLE
preserve terminal window output for windows

### DIFF
--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -47,11 +47,12 @@ class Runner {
         reject(`Error: Cannot find path ${binPath}`);
       }
 
-      const runner = os.platform() === 'win32' ? 'node.cmd' : 'node';
+      const isWindows = os.platform() === 'win32';
+      const runner = isWindows ? 'node.cmd' : 'node';
       this.childProcess = spawn(runner, [...finalArgs, cliPath, args], {
         cwd: this.rootDir,
         shell: false,
-        detached: true
+        detached: !isWindows
       });
 
       this.childProcess.on('close', code => {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #32 

## Summary of Changes
1. For Windows, don't `detach` spawned process