### PR TITLE
enhancement/issue 38 refactor `stopCommand` implementation

### DIFF
--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -81,13 +81,12 @@ class Runner {
   }
 
   stopCommand() {
-    if (this.childProcess) {
-      if (os.platform() === 'win32') {
-        spawn('taskkill', ['/pid', this.childProcess.pid, '/t', '/f']);
-      } else {
-        process.kill(-this.childProcess.pid, 'SIGKILL');
+    return new Promise((resolve) => {
+      if (this.childProcess) {
+        this.childProcess.kill();
+        resolve();
       }
-    }
+    });
   }
 
   teardown(additionalFiles = []) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #38 

## Summary of Changes
1. Use the spawned process' own `kill` method in `stopCommand`