### PR TITLE
support node 20 for github actions matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - ubuntu-20.04
           - windows-latest
-        node: [18]
+        node: [18, 20]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolve #42 

## Summary of Changes
1. Add Node `20.x` to GitHub Actions OS matrix