### PR TITLE
bug/issue 44 conditionally configure spawned process `stdio`

### DIFF
--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -53,7 +53,8 @@ class Runner {
       this.childProcess = spawnAction(executable, [...finalArgs, cliPath, args], {
         cwd: this.rootDir,
         shell: false,
-        detached: !isWindows
+        detached: !isWindows,
+        stdio: this.enableStdOut ? 'inherit' : null
       });
 
       this.childProcess.on('close', code => {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #44 

## Summary of Changes
1. Conditionally set `stdio` option when spawning the `runCommand` process