### PR TITLE
bug: do not `reject` on process stderr

### DIFF
--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -76,7 +76,6 @@ class Runner {
         if (this.enableStdOut) {
           console.error(err);
         }
-        reject(err);
       });
 
       this.childProcess.stdout.on('data', (data) => {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #65

## Summary of Changes
1. Remove `reject` from process stderr handling