### PR TITLE
Enhancement/issue 64 convert to async

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,15 @@ const cliPath = fileURLToPath(new URL('./path/to/your/cli.js', import.meta.url))
 const buildDir = fileURLToPath(new URL('./build', import.meta.url)); // required
 
 // this will also create the directory as well
-runner.setup(buildDir);
+await runner.setup(buildDir);
 
 // runs your CLI
 // use the second param to pass any args
-runner.runCommand(cliPath);
+await runner.runCommand(cliPath);
 
 // teardown buildDir
-runner.teardown();
+await runner.teardown();
 ```
-
-You can optionally `await` these methods as well, depending on your needs.
 
 > _See [our tests](https://github.com/thescientist13/gallinago/blob/master/test/cases/runner-cli/runner.cli.spec.js) to see **Gallinago** in action!_
 
@@ -66,13 +64,13 @@ The `Runner` constructor returns a new instance of `Runner`.
 ```js
 import { Runner } from 'gallinago';
 
-const runner = new Runner();  // pass true to the constructor to enable stdout
+const runner = new Runner();  // pass true to the constructor to print stdout and stderr
 ```
 
 #### Options
 
 `Runner` takes two boolean flags (`true`|`false`)
-- Standard Out - pass `true` to have the Runner log to `stdout`
+- Enable Debug - pass `true` to have the Runner log `stdout` and `stderr`
 - Forward Parent Args - pass `true` and any `node` flags passed to the parent process will be made available to the child process
 
 ### Runner.setup (required)
@@ -80,7 +78,7 @@ const runner = new Runner();  // pass true to the constructor to enable stdout
 `Runner.setup` initializes a directory for your CLI to be run in.  Returns a `Promise`.
 
 ```js
-runner.setup(__dirname);
+await runner.setup(__dirname);
 ```
 
 Optionally, you can provide "setup" files if you want to copy additional files into the target directory, say from _node_modules_ or a fixtures folder.  You can provide these files as an array of objects.
@@ -92,7 +90,7 @@ An third options object can be provided with the following supported options
 - `create` - automatically create the directory provided in the first param (default is `true`)
 
 ```js
-runner.setup(__dirname, [{
+await runner.setup(__dirname, [{
   source: path.join(process.cwd(), 'node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js'),
   destination: path.join(__dirname, 'build', 'webcomponents-bundle.js')
 }], {
@@ -105,7 +103,7 @@ runner.setup(__dirname, [{
 `Runner.runCommand` runs the script provided to Gallinago against the directory provided in `Runner.setup`.  Use the second param to pass any args to your CLI.  Returns a `Promise`.
 
 ```js
-runner.runCommand(
+await runner.runCommand(
   '/path/to/cli.js',
   '--version'
 );
@@ -114,7 +112,7 @@ runner.runCommand(
 You can also provided an array as the second param to support forwarding individual args, useful when using projects like [**commander**](https://www.npmjs.com/package/commander):
 
 ```js
-runner.runCommand(
+await runner.runCommand(
   '/path/to/cli.js',
   ["--name", "my-app"]
 );
@@ -125,26 +123,28 @@ runner.runCommand(
 `runCommand` additionally takes an options object as the third param.  With it you can further customize the runner:
 
 ```js
-runner.runCommand(
+await runner.runCommand(
   '/path/to/cli.js',
   '--version',
-  { async: true }
+  { background: true }
 );
 ```
 
-- `async` - By default `runCommand` runs synchronously using Node's `spawnSync`, which will block until the command completes  With `async: true`, this will now use `spawn`, which is a better for use cases like starting a web server where you _don't_ want to block the event loop.
+- `background` - By default `runCommand` resolves after the command finishes executing,
+ with `{ background: true }`, it will resolve after the command spawns. This is useful for
+ waiting for specific outputs.
 
 ### Runner.teardown
 
 `Runner.teardown` deletes any `setupFiles` provided in `Runner.setup`.  Returns a `Promise`.
 
 ```js
-runner.teardown();
+await runner.teardown();
 ```
 
 You can pass additional files or directories to `teardown` to have **gallinago** delete those too.
 ```js
-runner.teardown([
+await runner.teardown([
   path.join(__dirname, 'build'),
   path.join(__dirname, 'fixtures'),
   .
@@ -163,9 +163,8 @@ In certain circumstances, the command (process) you are running may do a couple 
 
 To support this in Gallinago, you can use `Runner.stopCommand` to kill any and all processes associated with your `runCommand`.
 
-
 ```js
-runner.stopCommand();
+await runner.stopCommand();
 ```
 
 > _**Note**: When used with something like mocha, you'll need to [use a `setTimeout` to work around the hung process and still advance the parent Mocha process](https://stackoverflow.com/a/24862303/417806).  See [our spec for this test case](https://github.com/thescientist13/gallinago/blob/master/test/cases/runner-cli-stop/runner.cli-stop.spec.js) for a complete example._

--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -26,6 +26,8 @@ class Runner {
   }
 
   async setup(rootDir, setupFiles = null, options = { create: true }) {
+    setupFiles ??= [];
+
     this.#setRootDir(rootDir);
     this.#setSetupFiles(setupFiles);
 
@@ -41,7 +43,7 @@ class Runner {
       }
     }
 
-    for (const file of setupFiles ?? []) {
+    for (const file of setupFiles) {
       await fs.mkdir(path.dirname(file.destination), { recursive: true });
       await fs.copyFile(file.source, file.destination);
     }
@@ -176,8 +178,6 @@ class Runner {
   }
 
   #setSetupFiles(setupFiles) {
-    setupFiles ??= [];
-
     if (
       !Array.isArray(setupFiles) ||
       !setupFiles.every((file) => 'source' in file && 'destination' in file)

--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import { spawn, spawnSync } from 'child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
 
 class Runner {
   #rootDir;

--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -4,124 +4,203 @@ import path from 'path';
 import { spawn, spawnSync } from 'child_process';
 
 class Runner {
-  constructor(enableStdOut = false, forwardParentArgs = false) {
-    this.enableStdOut = enableStdOut; // debugging tests
-    this.forwardParentArgs = forwardParentArgs;
-    this.setupFiles = [];
-    this.childProcess = null;
+  #rootDir;
+  #setupFiles = [];
+  #childProcess = null;
+
+  #enableDebug = false;
+  #forwardParentArgs = false;
+
+  // JS strings can be up to 2^53 - 1 in length,
+  // so no need to worry about overflow
+  // https://262.ecma-international.org/16.0/index.html#sec-ecmascript-language-types-string-type
+  #stdOutBuffer = '';
+  #stdErrBuffer = '';
+
+  #stdOutSubscribers = [];
+  #stdErrSubscribers = [];
+
+  constructor(enableDebug = false, forwardParentArgs = false) {
+    this.#enableDebug = enableDebug; // debugging tests
+    this.#forwardParentArgs = forwardParentArgs;
   }
 
-  setup(rootDir, setupFiles = [], options = { create: true }) {
-    this.setupFiles = setupFiles;
+  async setup(rootDir, setupFiles = null, options = { create: true }) {
+    this.#setRootDir(rootDir);
+    this.#setSetupFiles(setupFiles);
 
-    return new Promise((resolve, reject) => {
-      if (path.isAbsolute(rootDir)) {
-        this.rootDir = rootDir;
-
-        if (options.create) {
-          fs.mkdirSync(this.rootDir, { recursive: true });
+    if (options.create) {
+      try {
+        await fs.mkdir(this.#rootDir, { recursive: true });
+      } catch (err) {
+        if (err.message?.startsWith('EEXIST: file already exists')) {
+          // Do nothing
+        } else {
+          throw err;
         }
-
-        if (setupFiles.length > 0) {
-          setupFiles.forEach((file) => {
-            fs.mkdirSync(path.dirname(file.destination), { recursive: true });
-            fs.copyFileSync(file.source, file.destination);
-          });
-        }
-
-        resolve();
-      } else {
-        reject('Error: rootDir is not an absolute path');
       }
-    });
+    }
+
+    for (const file of setupFiles ?? []) {
+      await fs.mkdir(path.dirname(file.destination), { recursive: true });
+      await fs.copyFile(file.source, file.destination);
+    }
   }
 
-  runCommand(binPath, args, options = {}) {
-    return new Promise((resolve, reject) => {
-      const executable = 'node';
-      const isWindows = os.platform() === 'win32';
-      const cliPath = binPath;
-      const forwardArgs = this.forwardParentArgs ? process.execArgv : [];
-      const finalArgs = [...forwardArgs, cliPath];
-      const spawnAction = options.async ? spawn : spawnSync;
-      let err = '';
+  async runCommand(binPath, args, options = { background: false }) {
+    const executable = 'node';
+    const isWindows = os.platform() === 'win32';
+    const forwardArgs = this.#forwardParentArgs ? process.execArgv : [];
+    const finalArgs = [...forwardArgs, binPath];
 
-      if (Array.isArray(args)) {
-        finalArgs.push(...args);
-      } else if (typeof args === 'string') {
-        finalArgs.push(args);
-      }
+    if (Array.isArray(args)) {
+      finalArgs.push(...args);
+    } else if (typeof args === 'string') {
+      finalArgs.push(args);
+    }
 
-      if (!fs.existsSync(binPath)) {
-        reject(`Error: Cannot find path ${binPath}`);
-      }
+    await this.#throwIfBinNotExist(binPath);
 
-      this.childProcess = spawnAction(executable, finalArgs, {
-        cwd: this.rootDir,
-        shell: false,
-        detached: !isWindows,
-        stdio: this.enableStdOut ? 'inherit' : null
-      });
-
-      this.childProcess.on('close', code => {
-        if (err !== '' && code && code !== 0) {
-          reject(err);
-          return;
-        }
-        resolve();
-      });
-
-      this.childProcess.stderr.on('data', (data) => {
-        err = data.toString('utf8');
-        if (this.enableStdOut) {
-          console.error(err);
-        }
-      });
-
-      this.childProcess.stdout.on('data', (data) => {
-        if (this.enableStdOut) {
-          console.log(data.toString('utf8'));
-        }
-      });
+    this.#childProcess = spawn(executable, finalArgs, {
+      cwd: this.#rootDir,
+      shell: false,
+      detached: !isWindows,
     });
+
+    this.#childProcess.stdout.on('data', this.#handleStdOut.bind(this));
+    this.#childProcess.stderr.on('data', this.#handleStdErr.bind(this));
+
+    if (options.background) {
+      // Resolve immediately so caller can start processing outputs
+      return new Promise((resolve, reject) => {
+        this.#childProcess.on('spawn', resolve);
+        this.#childProcess.on('error', reject);
+      });
+    } else {
+      // Resolve when process exits
+      return new Promise((resolve, reject) => {
+        this.#childProcess.on('error', reject);
+        this.#childProcess.on('close', (code) => {
+          if (code) {
+            reject(
+              new Error(`Error: Child process exited with error code ${code}.`)
+            );
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
+  }
+
+  getStdOut() {
+    return this.#stdOutBuffer;
+  }
+
+  getStdErr() {
+    return this.#stdErrBuffer;
+  }
+
+  onStdOut(callback, options = { replay: true }) {
+    if (options.replay && this.#stdOutBuffer.length > 0) {
+      callback(this.#stdOutBuffer);
+    }
+
+    this.#stdOutSubscribers.push(callback);
+  }
+
+  onStdErr(callback, options = { replay: true }) {
+    if (options.replay && this.#stdErrBuffer.length > 0) {
+      callback(this.#stdErrBuffer);
+    }
+
+    this.#stdErrSubscribers.push(callback);
   }
 
   stopCommand() {
-    return new Promise((resolve) => {
-      if (this.childProcess) {
-        this.childProcess.kill();
-        resolve();
-      }
-    });
+    if (!this.#childProcess) {
+      return;
+    }
+
+    if (!this.#childProcess.kill()) {
+      const processID = this.#childProcess.pid;
+      throw new Error(
+        `Error: Failed to kill child process (PID: ${processID})`
+      );
+    }
   }
 
-  teardown(additionalFiles = []) {
-    return new Promise((resolve, reject) => {
-      try {
-        (this.setupFiles || []).concat(additionalFiles).forEach((file) => {
-          const deletePath = file.destination
-            ? file.destination
-            : file;
+  async teardown(additionalFiles = []) {
+    try {
+      for (const file of [...this.#setupFiles, ...additionalFiles]) {
+        const deletePath = file.destination ? file.destination : file;
 
-          if (fs.existsSync(deletePath)) {
-            if (fs.lstatSync(deletePath).isDirectory()) {
-              fs.rmSync(deletePath, { recursive: true });
-            } else {
-              fs.unlinkSync(deletePath);
-            }
-          }
-        });
-
-        this.setupFiles = [];
-        resolve();
-      } catch (err) {
-        console.log(err);
-        reject(err);
+        await fs.rm(deletePath, { recursive: true });
       }
-    });
+
+      this.#setupFiles = [];
+    } catch (err) {
+      console.log(err);
+      throw err;
+    }
+  }
+
+  #handleStdOut(data) {
+    const text = data.toString('utf8');
+    this.#stdOutBuffer += text;
+
+    if (this.#enableDebug) {
+      console.log(text);
+    }
+
+    this.#stdOutSubscribers.forEach((callback) => callback(text));
+  }
+
+  #handleStdErr(data) {
+    const text = data.toString('utf8');
+    this.#stdErrBuffer += text;
+
+    if (this.#enableDebug) {
+      console.error(text);
+    }
+
+    this.#stdErrSubscribers.forEach((callback) => callback(text));
+  }
+
+  #setRootDir(rootDir) {
+    if (!path.isAbsolute(rootDir)) {
+      throw new Error('Error: rootDir is not an absolute path');
+    }
+
+    this.#rootDir = rootDir;
+  }
+
+  #setSetupFiles(setupFiles) {
+    setupFiles ??= [];
+
+    if (
+      !Array.isArray(setupFiles) ||
+      !setupFiles.every((file) => 'source' in file && 'destination' in file)
+    ) {
+      throw new Error(
+        'SetupFiles must be an array with source and destination'
+      );
+    }
+
+    this.#setupFiles = setupFiles;
+  }
+
+  async #throwIfBinNotExist(binPath) {
+    try {
+      await fs.access(binPath);
+    } catch (err) {
+      if (err.message.startsWith('ENOENT: no such file or directory')) {
+        throw new Error(`Error: Cannot find path ${binPath}`);
+      } else {
+        throw err;
+      }
+    }
   }
 }
 
-export {
-  Runner
-};
+export { Runner };

--- a/test/cases/runner-cli-args-array/runner.cli-args-array.spec.js
+++ b/test/cases/runner-cli-args-array/runner.cli-args-array.spec.js
@@ -29,10 +29,10 @@ describe('CLI Fixture', function() {
   describe('default options with relative path with args passed as an array', function() {
     let runner;
 
-    before(function() {
+    before(async function() {
       runner = new Runner();
-      runner.setup(outputPath);
-      runner.runCommand(
+      await runner.setup(outputPath);
+      await runner.runCommand(
         `${fixturesPath}/cli.js`, // binPath
         [fixturesPath] // args
       );
@@ -62,8 +62,8 @@ describe('CLI Fixture', function() {
       expect(fs.existsSync(`${outputPath}/.mocharc.cjs`)).to.be.equal(true);
     });
 
-    it('should delete the output directory when told', function() {
-      runner.teardown([outputPath]);
+    it('should delete the output directory when told', async function() {
+      await runner.teardown([outputPath]);
 
       expect(fs.existsSync(outputPath)).to.be.equal(false);
     });
@@ -72,10 +72,10 @@ describe('CLI Fixture', function() {
   describe('setup with setupFiles', function() {
     let runner;
 
-    before(function() {
+    before(async function() {
       runner = new Runner();
-      runner.setup(outputPath, setupFiles);
-      runner.runCommand(
+      await runner.setup(outputPath, setupFiles);
+      await runner.runCommand(
         `${fixturesPath}/cli.js`, // binPath
         fixturesPath // args
       );
@@ -109,15 +109,15 @@ describe('CLI Fixture', function() {
       expect(fs.existsSync(`${outputPath}/webcomponents-bundle.js`)).to.be.equal(true);
     });
 
-    it('should delete the setup file we provided', function() {
+    it('should delete the setup file we provided', async function() {
       const setupFile = path.join(outputPath, 'webcomponents-bundle.js');
-      runner.teardown();
+      await runner.teardown();
 
       expect(fs.existsSync(setupFile)).to.be.equal(false);
       expect(fs.existsSync(outputPath)).to.be.equal(true);
 
       // cleanup everything
-      runner.teardown([outputPath]);
+      await runner.teardown([outputPath]);
       expect(fs.existsSync(outputPath)).to.be.equal(false);
     });
   });

--- a/test/cases/runner-cli-create-output-false/runner.cli-create-output-false.spec.js
+++ b/test/cases/runner-cli-create-output-false/runner.cli-create-output-false.spec.js
@@ -23,9 +23,9 @@ describe('CLI Fixture', function() {
   describe('default options with relative path that should not create the output dir', function() {
     let runner;
 
-    before(function() {
+    before(async function() {
       runner = new Runner();
-      runner.setup(outputPath, null, { create: false });
+      await runner.setup(outputPath, null, { create: false });
     });
 
     it('should have created the output folder', function() {

--- a/test/cases/runner-cli-error/runner-cli-error.spec.js
+++ b/test/cases/runner-cli-error/runner-cli-error.spec.js
@@ -10,48 +10,46 @@
  * runCommand('test/fixtures/cliiiii')
  *
  */
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import { Runner } from '../../../src/index.js';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import assert from 'node:assert/strict';
 
 describe('CLI Error Handling', function() {
-
   describe('default options with incorrect binary path', function() {
     it('should throw an error that module cannot be found', async function() {
       const binPath = 'test/fixtures/cliiiiii.js';
       const runner = new Runner();
-      await expect(runner.runCommand(binPath)).to.be.rejectedWith(
-        `Error: Cannot find path ${binPath}`
-      );
+      await assert.rejects(runner.runCommand(binPath), {
+        message: `Error: Cannot find path ${binPath}`,
+      });
     });
   });
 
   describe('default options with relative path for rootDir', function() {
     it('should throw an error that rootDir is not absolute', async function() {
       const runner = new Runner();
-      await expect(
-        runner.setup('../../test/fixtures/cli.js')
-      ).to.be.rejectedWith('Error: rootDir is not an absolute path');
+      await assert.rejects(runner.setup('../../test/fixtures/cli.js'), {
+        message: 'Error: rootDir is not an absolute path',
+      });
     });
   });
 
   describe('handling (and bubbling) an exception from the child process', function() {
     it('should throw an error that this is child throwing (a Promise.reject)', async function() {
       const runner = new Runner();
-      await expect(
+      await assert.rejects(
         runner.runCommand(
-          path.join(process.cwd(), 'test/fixtures/cli-promise-rejection.js'),
-          null,
-          { async: true }
-        )
-      ).to.be.rejectedWith(
-        'Error: Child process throwing a Promise.reject to the parent.'
+          path.join(process.cwd(), 'test/fixtures/cli-promise-rejection.js')
+        ),
+        {
+          message: 'Error: Child process exited with error code 1.',
+        }
+      );
+
+      assert.match(
+        runner.getStdErr(),
+        /Error: Child process throwing a Promise.reject to the parent./
       );
     });
   });
-
 });

--- a/test/cases/runner-cli-error/runner-cli-error.spec.js
+++ b/test/cases/runner-cli-error/runner-cli-error.spec.js
@@ -10,46 +10,48 @@
  * runCommand('test/fixtures/cliiiii')
  *
  */
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import { Runner } from '../../../src/index.js';
-import assert from 'node:assert/strict';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
 
 describe('CLI Error Handling', function() {
+
   describe('default options with incorrect binary path', function() {
     it('should throw an error that module cannot be found', async function() {
       const binPath = 'test/fixtures/cliiiiii.js';
       const runner = new Runner();
-      await assert.rejects(runner.runCommand(binPath), {
-        message: `Error: Cannot find path ${binPath}`,
-      });
+      await expect(runner.runCommand(binPath)).to.be.rejectedWith(
+        `Error: Cannot find path ${binPath}`
+      );
     });
   });
 
   describe('default options with relative path for rootDir', function() {
     it('should throw an error that rootDir is not absolute', async function() {
       const runner = new Runner();
-      await assert.rejects(runner.setup('../../test/fixtures/cli.js'), {
-        message: 'Error: rootDir is not an absolute path',
-      });
+      await expect(
+        runner.setup('../../test/fixtures/cli.js')
+      ).to.be.rejectedWith('Error: rootDir is not an absolute path');
     });
   });
 
   describe('handling (and bubbling) an exception from the child process', function() {
     it('should throw an error that this is child throwing (a Promise.reject)', async function() {
       const runner = new Runner();
-      await assert.rejects(
+      await expect(
         runner.runCommand(
-          path.join(process.cwd(), 'test/fixtures/cli-promise-rejection.js')
-        ),
-        {
-          message: 'Error: Child process exited with error code 1.',
-        }
-      );
-
-      assert.match(
-        runner.getStdErr(),
-        /Error: Child process throwing a Promise.reject to the parent./
+          path.join(process.cwd(), 'test/fixtures/cli-promise-rejection.js'),
+          null,
+          { async: true }
+        )
+      ).to.be.rejectedWith(
+        'Error: Child process throwing a Promise.reject to the parent.'
       );
     });
   });
+
 });

--- a/test/cases/runner-cli-error/runner-cli-error.spec.js
+++ b/test/cases/runner-cli-error/runner-cli-error.spec.js
@@ -49,6 +49,10 @@ describe('CLI Error Handling', function() {
           { async: true }
         )
       ).to.be.rejectedWith(
+        'Error: Child process exited with error code 1.'
+      );
+
+      expect(runner.getStdErr()).to.include(
         'Error: Child process throwing a Promise.reject to the parent.'
       );
     });

--- a/test/cases/runner-cli-stop/runner.cli-stop.spec.js
+++ b/test/cases/runner-cli-stop/runner.cli-stop.spec.js
@@ -28,18 +28,17 @@ describe('Server Fixture for Manual Process Stop', function() {
 
     before(async function() {
       runner = new Runner();
-      runner.setup(outputPath);
+      await runner.setup(outputPath);
+      await runner.runCommand(`${fixturesPath}/server.js`, null, {
+        background: true,
+      });
 
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve();
-        }, 5000);
-
-        runner.runCommand(
-          `${fixturesPath}/server.js`,
-          null,
-          { async: true }
-        );
+      await new Promise((resolve) => {
+        runner.onStdOut((message) => {
+          if (message.includes('server started on port 8080')) {
+            resolve();
+          }
+        });
       });
     });
 
@@ -65,11 +64,8 @@ describe('Server Fixture for Manual Process Stop', function() {
       runner.stopCommand();
     });
 
-    after(function() {
-      runner.teardown([
-        path.join(outputPath)
-      ]);
+    after(async function() {
+      await runner.teardown([path.join(outputPath)]);
     });
   });
-
 });

--- a/test/cases/runner-cli/runner.cli.spec.js
+++ b/test/cases/runner-cli/runner.cli.spec.js
@@ -29,10 +29,10 @@ describe('CLI Fixture', function() {
   describe('default options with relative path', function() {
     let runner;
 
-    before(function() {
+    before(async function() {
       runner = new Runner();
-      runner.setup(outputPath);
-      runner.runCommand(
+      await runner.setup(outputPath);
+      await runner.runCommand(
         `${fixturesPath}/cli.js`, // binPath
         fixturesPath // args
       );
@@ -62,8 +62,8 @@ describe('CLI Fixture', function() {
       expect(fs.existsSync(`${outputPath}/.mocharc.cjs`)).to.be.equal(true);
     });
 
-    it('should delete the output directory when told', function() {
-      runner.teardown([outputPath]);
+    it('should delete the output directory when told', async function() {
+      await runner.teardown([outputPath]);
 
       expect(fs.existsSync(outputPath)).to.be.equal(false);
     });
@@ -72,10 +72,10 @@ describe('CLI Fixture', function() {
   describe('setup with setupFiles', function() {
     let runner;
 
-    before(function() {
+    before(async function() {
       runner = new Runner();
-      runner.setup(outputPath, setupFiles);
-      runner.runCommand(
+      await runner.setup(outputPath, setupFiles);
+      await runner.runCommand(
         `${fixturesPath}/cli.js`, // binPath
         fixturesPath // args
       );
@@ -109,15 +109,15 @@ describe('CLI Fixture', function() {
       expect(fs.existsSync(`${outputPath}/webcomponents-bundle.js`)).to.be.equal(true);
     });
 
-    it('should delete the setup file we provided', function() {
+    it('should delete the setup file we provided', async function() {
       const setupFile = path.join(outputPath, 'webcomponents-bundle.js');
-      runner.teardown();
+      await runner.teardown();
 
       expect(fs.existsSync(setupFile)).to.be.equal(false);
       expect(fs.existsSync(outputPath)).to.be.equal(true);
 
       // cleanup everything
-      runner.teardown([outputPath]);
+      await runner.teardown([outputPath]);
       expect(fs.existsSync(outputPath)).to.be.equal(false);
     });
   });

--- a/test/cases/runner-debug/runner.debug.spec.js
+++ b/test/cases/runner-debug/runner.debug.spec.js
@@ -25,10 +25,10 @@ describe('CLI Fixture w/debug (stdOut) enabled', function() {
   describe('default options with relative path', function() {
     let runner;
 
-    before(function() {
+    before(async function() {
       runner = new Runner();
-      runner.setup(outputPath);
-      runner.runCommand(
+      await runner.setup(outputPath);
+      await runner.runCommand(
         `${fixturesPath}/cli.js`, // binPath
         fixturesPath // args
       );
@@ -58,10 +58,8 @@ describe('CLI Fixture w/debug (stdOut) enabled', function() {
       expect(fs.existsSync(`${outputPath}/.mocharc.cjs`)).to.be.equal(true);
     });
 
-    after(function() {
-      runner.teardown([
-        path.join(outputPath)
-      ]);
+    after(async function() {
+      await runner.teardown([path.join(outputPath)]);
     });
   });
 });

--- a/test/cases/runner-forward-args/runner.forward-args.spec.js
+++ b/test/cases/runner-forward-args/runner.forward-args.spec.js
@@ -6,7 +6,7 @@
  * Should run cli.js runCommand successfully and outputs the expected result.
  *
  * runCommand
- * 
+ *
  * runner = new Runner(false, true);
  * runCommand('cli.js')
  *
@@ -26,10 +26,10 @@ describe('Forward Parent Args', function() {
   describe('default options with Forward Parent Args set to true', function() {
     let runner;
 
-    before(function() {
+    before(async function() {
       runner = new Runner(false, true);
-      runner.setup(outputPath);
-      runner.runCommand(
+      await runner.setup(outputPath);
+      await runner.runCommand(
         path.join(currentPath, 'cli.js') // binPath
       );
     });
@@ -52,10 +52,8 @@ describe('Forward Parent Args', function() {
       expect(contents).to.be.equal('--debug-port=3333');
     });
 
-    after(function() {
-      runner.teardown([
-        path.join(outputPath)
-      ]);
+    after(async function() {
+      await runner.teardown([path.join(outputPath)]);
     });
   });
 });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

This PR is primarily about converting to async only. I've also implemented some of our other planned features.

## BREAKING CHANGES:
1. Removed the `async` option making it async only. This simplifies the implementation of this library. 

2. The `runCommand` throws the error code if the process fails instead of the stdErr output. The error output can be accessed from `getStdErr`.

## Features:
1. Passing `{background: true}` makes `runCommand` return before the process ends. The primary use for this is running a process in the background such as a dev server.

2. Use `onStdOut` and `onStdErr` to hook into process outputs as they stream. The primary use for this is to combine with `{background: true}` to wait for a process to be ready. e.g. "server started on port 8080". Pass `{replay: true}` to immediately receive all buffered output so far.

3. `getStdOut` and `getStdErr` return the output buffers. The primary use for this is to assert on outputs after the command finishes.

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
Addresses #64 , also #61 , #58 , #59

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
1. [x] Removed async option
2. [x] Added background option
3. [x] Added onStdOut/Err hooks
4. [x] Added getStdOut/Err hooks
5. [x] Namespaced node imports
6. [x] Updated docs
7. [x] Use private elements in Runner
8. [x] Add some input validation on setupFiles
9. [x] Update tests
10. [ ] Add more tests for code coverage