### PR TITLE
bug: #72 check for `childProcess.killed` before resolving from `stopCommand`

### DIFF
--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -87,10 +87,7 @@ class Runner {
   stopCommand() {
     return new Promise((resolve) => {
       if (this.childProcess) {
-        this.childProcess.on('exit', () => {
-          resolve();
-        })
-
+        this.childProcess.on('exit', resolve);
         this.childProcess.kill();
       } else {
         resolve()


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #72 

## Summary of Changes
1. Add an on exit event callback and resolve in stop command

> You can see the patch applied here - https://github.com/ProjectEvergreen/greenwood/pull/1573

----

I picked the 50ms kind of at random, not sure if we should lower it raise it or whatnot, but for this now fixes the immediate problem, so totally happy to open an improvement issue if anyone can think of a better way to do it 😅 