### PR TITLE
fix: #76 accumulate stderr

### DIFF
--- a/src/lib/runner.js
+++ b/src/lib/runner.js
@@ -70,7 +70,7 @@ class Runner {
       });
 
       this.childProcess.stderr.on('data', (data) => {
-        err = data.toString('utf8');
+        err += data.toString("utf8"); // Max string size ~1GiB
         if (this.enableStdOut) {
           console.error(err);
         }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

I believe the cause of CI failing is that error messages are being overwritten by subsequent writes to `stderr`. This PR fixes the failing CI by concatenating the stderr buffer rather than replacing it.

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
Resolves #76

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists
-->

1. [x] Use `+=` to buffer the stderr output